### PR TITLE
Change ngx_socket example

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,10 +192,11 @@ http {
             content_by_php_block {
                 $fd = ngx_socket_create();
 
-                yield ngx_socket_connect($fd, "hq.sinajs.cn", 80);
+                yield ngx_socket_connect($fd, "httpbin.org", 80);
 
-                $send_buf = "GET /list=s_sh000001 HTTP/1.0\r\n
-                                            Host: hq.sinajs.cn\r\nConnection: close\r\n\r\n";
+                $send_buf = "GET /get HTTP/1.1\r\n
+                                            Host: httpbin.org\r\n
+                                            Connection: close\r\n\r\n";
                 yield ngx_socket_send($fd, $send_buf, strlen($send_buf));
 
                 $recv_buf = "";


### PR DESCRIPTION
[hq.sinajs.cn](http://hq.sinajs.cn) always return Forbidden.

Changed to [http://httpbin.org](http://httpbin.org), that return the info of the request. And have more util options.

Also test, than a change in the README.md, don't start the CI.