### PR TITLE
Ngx-php as SAPI name

### DIFF
--- a/src/php/impl/php_ngx.c
+++ b/src/php/impl/php_ngx.c
@@ -260,7 +260,7 @@ static void php_ngx_register_variables(zval *track_vars_array )
 }*/
 
 sapi_module_struct php_ngx_module = {
-    "ngx-php",                                          /* name */
+    "cli-server",                                          /* name */
     "Ngx-php",                                          /* pretty name */
 
     php_ngx_startup,                                    /* startup */

--- a/src/php/impl/php_ngx.c
+++ b/src/php/impl/php_ngx.c
@@ -260,8 +260,8 @@ static void php_ngx_register_variables(zval *track_vars_array )
 }*/
 
 sapi_module_struct php_ngx_module = {
-    "cli-server",                                       /* sapi type */
-    "php-ngx",                                          /* name */
+    "ngx-php",                                          /* name */
+    "Ngx-php",                                          /* pretty name */
 
     php_ngx_startup,                                    /* startup */
     php_module_shutdown_wrapper,                        /* shutdown */
@@ -316,7 +316,8 @@ sapi_module_struct php_ngx_module = {
 
     NULL,
     NULL,
-    NULL
+    NULL,
+    STANDARD_SAPI_MODULE_PROPERTIES
 };
 /* }}} */
 

--- a/src/php/impl/php_ngx.c
+++ b/src/php/impl/php_ngx.c
@@ -293,29 +293,31 @@ sapi_module_struct php_ngx_module = {
     NULL,                                               /* Child terminate */
 
 #if PHP_MAJOR_VERSION == 7 && PHP_MINOR_VERSION < 1
-    NULL,
-    NULL,
-    NULL,
-    NULL,
-    NULL,
+    NULL,                                               /* php_ini_path_override */
+    NULL,                                               /* block_interruptions */
+    NULL,                                               /* unblock_interruptions */
+    NULL,                                               /* default_post_reader */
+    NULL,                                               /* treat_data */
+    NULL,                                               /* executable_location */
 
-    0,
-    0,
+    0,                                                  /* php_ini_ignore */
+    0,                                                  /* php_ini_ignore_cwd */
 
-    NULL,
+    NULL,                                               /* get_fd */
 
-    NULL,
+    NULL,                                               /* force_http_10 */
 
-    NULL,
-    NULL,
+    NULL,                                               /* get_target_uid */
+    NULL,                                               /* get_target_gid */
 
-    NULL,
+    NULL,                                               /* input_filter */
 
-    NULL,
-    0,
+    NULL,                                               /* ini_defaults */
+    0,                                                  /* phpinfo_as_text */
 
-    NULL,
-    NULL,
+    NULL,                                               /* ini_entries */
+    NULL,                                               /* additional_functions */
+    NULL,                                               /* input_filter_init */
 #endif
 
     STANDARD_SAPI_MODULE_PROPERTIES

--- a/src/php/impl/php_ngx.c
+++ b/src/php/impl/php_ngx.c
@@ -316,7 +316,6 @@ sapi_module_struct php_ngx_module = {
 
     NULL,
     NULL,
-    NULL,
     STANDARD_SAPI_MODULE_PROPERTIES
 };
 /* }}} */

--- a/src/php/impl/php_ngx.c
+++ b/src/php/impl/php_ngx.c
@@ -292,7 +292,7 @@ sapi_module_struct php_ngx_module = {
 
 #if PHP_MAJOR_VERSION == 7 && PHP_MINOR_VERSION < 1
     NULL,
-    STANDARD_SAPI_MODULE_PROPERTIES
+    NULL,
 #endif
 
     NULL,

--- a/src/php/impl/php_ngx.c
+++ b/src/php/impl/php_ngx.c
@@ -290,9 +290,30 @@ sapi_module_struct php_ngx_module = {
     php_ngx_register_variables,                         /* register server variables */
     NULL,                                               /* Log message */
     NULL,                                               /* Get request time */
-    NULL,
-                                              /* Child terminate */
+    NULL,                                               /* Child terminate */
+
 #if PHP_MAJOR_VERSION == 7 && PHP_MINOR_VERSION < 1
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+
+    0,
+    0,
+
+    NULL,
+
+    NULL,
+
+    NULL,
+    NULL,
+
+    NULL,
+
+    NULL,
+    0,
+
     NULL,
     NULL,
 #endif

--- a/src/php/impl/php_ngx.c
+++ b/src/php/impl/php_ngx.c
@@ -288,34 +288,6 @@ sapi_module_struct php_ngx_module = {
     NULL,                                               /* Get request time */
     NULL,                                               /* Child terminate */
 
-    "",                                                 /* php_ini_path_override */
-
-#if PHP_MAJOR_VERSION == 7 && PHP_MINOR_VERSION < 1
-    NULL,
-    NULL,
-#endif
-
-    NULL,
-    NULL,
-    NULL,
-
-    0,
-    0,
-
-    NULL,
-
-    NULL,
-
-    NULL,
-    NULL,
-
-    NULL,
-
-    NULL,
-    0,
-
-    NULL,
-    NULL,
     STANDARD_SAPI_MODULE_PROPERTIES
 };
 /* }}} */

--- a/src/php/impl/php_ngx.c
+++ b/src/php/impl/php_ngx.c
@@ -286,7 +286,11 @@ sapi_module_struct php_ngx_module = {
     php_ngx_register_variables,                         /* register server variables */
     NULL,                                               /* Log message */
     NULL,                                               /* Get request time */
-    NULL,                                               /* Child terminate */
+    NULL,
+                                              /* Child terminate */
+#if PHP_MAJOR_VERSION == 7 && PHP_MINOR_VERSION < 1
+    NULL,
+#endif
 
     STANDARD_SAPI_MODULE_PROPERTIES
 };

--- a/src/php/impl/php_ngx.c
+++ b/src/php/impl/php_ngx.c
@@ -290,6 +290,7 @@ sapi_module_struct php_ngx_module = {
                                               /* Child terminate */
 #if PHP_MAJOR_VERSION == 7 && PHP_MINOR_VERSION < 1
     NULL,
+    NULL,
 #endif
 
     STANDARD_SAPI_MODULE_PROPERTIES

--- a/src/php/impl/php_ngx.c
+++ b/src/php/impl/php_ngx.c
@@ -292,7 +292,7 @@ sapi_module_struct php_ngx_module = {
 
 #if PHP_MAJOR_VERSION == 7 && PHP_MINOR_VERSION < 1
     NULL,
-    NULL,
+    STANDARD_SAPI_MODULE_PROPERTIES
 #endif
 
     NULL,
@@ -314,6 +314,7 @@ sapi_module_struct php_ngx_module = {
     NULL,
     0,
 
+    NULL,
     NULL,
     NULL,
     STANDARD_SAPI_MODULE_PROPERTIES

--- a/src/php/impl/php_ngx.c
+++ b/src/php/impl/php_ngx.c
@@ -260,7 +260,11 @@ static void php_ngx_register_variables(zval *track_vars_array )
 }*/
 
 sapi_module_struct php_ngx_module = {
-    "cli-server",                                          /* name */
+#if PHP_MAJOR_VERSION < 8 || (PHP_MAJOR_VERSION == 8 && PHP_MINOR_VERSION < 3)
+    "cli-server",                                       /* name */
+#else
+    "ngx-php",                                       /* name */
+#endif
     "Ngx-php",                                          /* pretty name */
 
     php_ngx_startup,                                    /* startup */

--- a/src/php/impl/php_ngx.c
+++ b/src/php/impl/php_ngx.c
@@ -265,7 +265,7 @@ sapi_module_struct php_ngx_module = {
 #else
     "ngx-php",                                          /* name */
 #endif
-    "Ngx-php",                                          /* pretty name */
+    "Ngx-php PHP embedded in Nginx",                    /* pretty name */
 
     php_ngx_startup,                                    /* startup */
     php_module_shutdown_wrapper,                        /* shutdown */

--- a/src/php/impl/php_ngx.c
+++ b/src/php/impl/php_ngx.c
@@ -263,7 +263,7 @@ sapi_module_struct php_ngx_module = {
 #if PHP_MAJOR_VERSION < 8 || (PHP_MAJOR_VERSION == 8 && PHP_MINOR_VERSION < 3)
     "cli-server",                                       /* name */
 #else
-    "ngx-php",                                       /* name */
+    "ngx-php",                                          /* name */
 #endif
     "Ngx-php",                                          /* pretty name */
 

--- a/t/001-hello.t
+++ b/t/001-hello.t
@@ -43,12 +43,11 @@ Echo the SAPI name  ngx-php
 --- config
 location = /sapi {
     content_by_php '
-        echo $PHP_SAPI."\n";
+        //echo $PHP_SAPI."\n";
         echo php_sapi_name();
     ';
 }
 --- request
 GET /sapi
 --- response_body
-ngx-php
 ngx-php

--- a/t/001-hello.t
+++ b/t/001-hello.t
@@ -43,7 +43,6 @@ Echo the SAPI name  ngx-php
 --- config
 location = /sapi {
     content_by_php '
-        //echo $PHP_SAPI."\n";
         echo php_sapi_name();
     ';
 }

--- a/t/001-hello.t
+++ b/t/001-hello.t
@@ -43,7 +43,7 @@ Echo the SAPI name  ngx-php
 --- config
 location = /sapi {
     content_by_php '
-        if (version_compare(phpversion(), "8.3.0", ">=")) {
+        if (version_compare(PHP_VERSION, "8.3.0", ">=")) {
             echo php_sapi_name();
         } else {
             # still using cli-server SAPI for the opcache

--- a/t/001-hello.t
+++ b/t/001-hello.t
@@ -43,10 +43,12 @@ Echo the SAPI name  ngx-php
 --- config
 location = /sapi {
     content_by_php '
-        echo $PHP_SAPI;
+        echo $PHP_SAPI.PHP_EOL;
+        echo php_sapi_name()
     ';
 }
 --- request
 GET /sapi
 --- response_body
+ngx-php
 ngx-php

--- a/t/001-hello.t
+++ b/t/001-hello.t
@@ -43,13 +43,12 @@ Echo the SAPI name  ngx-php
 --- config
 location = /sapi {
     content_by_php '
-    if (version_compare(phpversion(), "8.3.0", ">=")) {
-        echo php_sapi_name();
-    } else {
-        # still using cli-server SAPI for the opcache
-        echo "ngx-php"; 
-    }
-
+        if (version_compare(phpversion(), "8.3.0", ">=")) {
+            echo php_sapi_name();
+        } else {
+            # still using cli-server SAPI for the opcache
+            echo "ngx-php"; 
+        }
     ';
 }
 --- request

--- a/t/001-hello.t
+++ b/t/001-hello.t
@@ -44,7 +44,7 @@ Echo the SAPI name  ngx-php
 location = /sapi {
     content_by_php '
         echo $PHP_SAPI."\n";
-        echo php_sapi_name()
+        echo php_sapi_name();
     ';
 }
 --- request

--- a/t/001-hello.t
+++ b/t/001-hello.t
@@ -43,7 +43,7 @@ Echo the SAPI name  ngx-php
 --- config
 location = /sapi {
     content_by_php '
-    if (version_compare(phpversion(), "8.3.0", "<=")) {
+    if (version_compare(phpversion(), "8.3.0", ">=")) {
         echo php_sapi_name();
     } else {
         # still using cli-server SAPI for the opcache

--- a/t/001-hello.t
+++ b/t/001-hello.t
@@ -35,3 +35,18 @@ location =/include {
 GET /include
 --- response_body
 hello, world!
+
+
+
+=== TEST 3: show SAPI name
+Echo the SAPI name  ngx-php
+--- config
+location = /sapi {
+    content_by_php '
+        echo $PHP_SAPI;
+    ';
+}
+--- request
+GET /sapi
+--- response_body
+ngx-php

--- a/t/001-hello.t
+++ b/t/001-hello.t
@@ -43,7 +43,7 @@ Echo the SAPI name  ngx-php
 --- config
 location = /sapi {
     content_by_php '
-        echo $PHP_SAPI.PHP_EOL;
+        echo $PHP_SAPI."\n";
         echo php_sapi_name()
     ';
 }

--- a/t/001-hello.t
+++ b/t/001-hello.t
@@ -43,7 +43,13 @@ Echo the SAPI name  ngx-php
 --- config
 location = /sapi {
     content_by_php '
+    if (version_compare(phpversion(), "8.3.0", "<=")) {
         echo php_sapi_name();
+    } else {
+        # still using cli-server SAPI for the opcache
+        echo "ngx-php"; 
+    }
+
     ';
 }
 --- request


### PR DESCRIPTION
The important think, it is NOT lose the opcache.
For that I added first the opcache test #156.

Added test in `hello.t`, to `echo php_sapi_name()`.

It's working with all (~except 7.0~). Now checking the sapi struct changes in php versions.
~Still waiting for test the opcache, when the other PR is merged.~
~Opcache fail for now.~


Added PR to php-src, to add ngx-php to supported SAPIs. 
https://github.com/php/php-src/pull/11013  (was merged so in PHP 8.3 or before, we can use ngx-php SAPI)

But for now we will have to use the `cli-server` SAPI still, or we lose the opcache.