### PR TITLE
Unbuntu 20.04 disable tests for PHP 8.2 & 8.3

### DIFF
--- a/.github/workflows/build_20.04.yml
+++ b/.github/workflows/build_20.04.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php_version: ["7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]
+        php_version: ["7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1"]
         nginx_version: ["1.20.2", "1.22.1", "1.24.0", "1.25.4"] # "1.12.2" fail to compile
         # Disable fail-fast to allow all failing versions to fail in a
         # single build, rather than stopping when the first one fails.

--- a/.github/workflows/build_20.04_dynamic.yml
+++ b/.github/workflows/build_20.04_dynamic.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php_version: ["7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]
+        php_version: ["7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1"]
         nginx_version: ["1.20.2", "1.22.1", "1.24.0", "1.25.4"] # "1.12.2" fail to compile
         # Disable fail-fast to allow all failing versions to fail in a
         # single build, rather than stopping when the first one fails.


### PR DESCRIPTION
To fix problem with JIT that it is not from ngx-php, than work without problems.