### PR TITLE
Update to nginx/1.29.0 the build development

### DIFF
--- a/.github/workflows/build_development.yml
+++ b/.github/workflows/build_development.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         php_version: ["8.5"]
-        nginx_version: ["1.28.0"] 
+        nginx_version: ["1.29.0"] 
         # Disable fail-fast to allow all failing versions to fail in a
         # single build, rather than stopping when the first one fails.
       fail-fast: false

--- a/.github/workflows/build_development.yml
+++ b/.github/workflows/build_development.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         php_version: ["8.5"]
-        nginx_version: ["1.28.0"] 
+        nginx_version: ["1.29.0"] 
         # Disable fail-fast to allow all failing versions to fail in a
         # single build, rather than stopping when the first one fails.
       fail-fast: false
@@ -45,6 +45,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:  { ref: development }
       - name: Install dependencies
         run: |
           sudo apt update

--- a/.github/workflows/build_development.yml
+++ b/.github/workflows/build_development.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         php_version: ["8.5"]
-        nginx_version: ["1.29.0"] 
+        nginx_version: ["1.28.0"] 
         # Disable fail-fast to allow all failing versions to fail in a
         # single build, rather than stopping when the first one fails.
       fail-fast: false


### PR DESCRIPTION
It's failing compiling:
https://github.com/rryqszq4/ngx-php/actions/runs/16644561019/job/47102000248?pr=203

We'll wait as 1st of each month (tomorrow) will run. So we will check if is a problem with PHP first.

EDIT: the scheduled workflow run only work with the master branch, so we need to change the master nightly using the dev branch.  I'll do it later, or we can't check the problems with new versions as they change each month.

Update: to use dev branch, for when is merged with the master branch.