### PR TITLE
Add nginx v1.30.0 to tests

### DIFF
--- a/.github/workflows/build_24.04.yml
+++ b/.github/workflows/build_24.04.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         php_version: ["8.2", "8.3", "8.4"]
         # Only nginx stable and mainline versions for faster tests
-        nginx_version: ["1.25.5", "1.26.0", "1.27.3", "1.28.0"]
+        nginx_version: ["1.25.5", "1.26.0", "1.27.3", "1.28.0", "1.30.0"]
         # Disable fail-fast to allow all failing versions to fail in a
         # single build, rather than stopping when the first one fails.
       fail-fast: false

--- a/.github/workflows/build_24.04_dynamic.yml
+++ b/.github/workflows/build_24.04_dynamic.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         php_version: ["8.2", "8.3", "8.4"] # "7.0", "7.1", "7.2", "7.3", 
         # Only nginx stable and mainline versions for faster tests
-        nginx_version: ["1.25.5", "1.26.0", "1.27.3"]
+        nginx_version: ["1.25.5", "1.26.0", "1.27.3", "1.30.0"]
         # Disable fail-fast to allow all failing versions to fail in a
         # single build, rather than stopping when the first one fails.
       fail-fast: false


### PR DESCRIPTION
Released 14 Apr 2026.

https://nginx.org/en/CHANGES-1.30